### PR TITLE
Attach event listeners once

### DIFF
--- a/webapp/lib/main_ui.dart
+++ b/webapp/lib/main_ui.dart
@@ -4,7 +4,6 @@
 library coda.ui;
 
 import 'dart:html';
-import 'dart:async';
 
 import 'config.dart';
 import 'data_model.dart';

--- a/webapp/lib/main_ui.dart
+++ b/webapp/lib/main_ui.dart
@@ -4,6 +4,7 @@
 library coda.ui;
 
 import 'dart:html';
+import 'dart:async';
 
 import 'config.dart';
 import 'data_model.dart';
@@ -36,6 +37,8 @@ class CodaUI {
   // Cache main elements of the UI
   Element tableHead = null;
   Element tableBody = null;
+  bool eventListenersAttached = false;
+
 
   CodaUI() {
     fbt.init();
@@ -55,29 +58,10 @@ class CodaUI {
     otherContent.text = text;
   }
 
-  displayDatasetView(Dataset dataset) {
-    // Prepare for displaying the dataset view by clearing up the DOM.
-    clearMessageCodingTable(); // Clear up the table before loading the new dataset.
-    otherContent.innerHtml = ''; // Clear out any of the other content, like error messages.
-    messageCodingNavButtons.attributes.remove('hidden'); // Show coding buttons
-
-    // (Re)initialise objects
-    this.dataset = dataset;
-    this.messages = [];
-    this.messageMap = {};
-
-    messageCodingTable.append(createTableHeader(dataset));
-
-    TableSectionElement body = new Element.tag('tbody');
-    this.tableBody = body;
-
-    dataset.messages.forEach((message) {
-      MessageViewModel messageViewModel = new MessageViewModel(message, dataset);
-      messages.add(messageViewModel);
-      messageMap[message.id] = messageViewModel;
-      body.append(messageViewModel.viewElement);
-    });
-    messageCodingTable.append(body);
+  attachEventListeners(Element messageCodingTable) {
+    // Attach the global listeners at most once
+    if (eventListenersAttached) return;
+    eventListenersAttached = true;
 
     messageCodingTable.onChange.listen((event) {
       var target = event.target;
@@ -168,6 +152,34 @@ class CodaUI {
         return;
       }
     });
+  }
+
+
+  displayDatasetView(Dataset dataset) {
+    // Prepare for displaying the dataset view by clearing up the DOM.
+    clearMessageCodingTable(); // Clear up the table before loading the new dataset.
+    otherContent.innerHtml = ''; // Clear out any of the other content, like error messages.
+    messageCodingNavButtons.attributes.remove('hidden'); // Show coding buttons
+
+    // (Re)initialise objects
+    this.dataset = dataset;
+    this.messages = [];
+    this.messageMap = {};
+
+    messageCodingTable.append(createTableHeader(dataset));
+
+    TableSectionElement body = new Element.tag('tbody');
+    this.tableBody = body;
+
+    dataset.messages.forEach((message) {
+      MessageViewModel messageViewModel = new MessageViewModel(message, dataset);
+      messages.add(messageViewModel);
+      messageMap[message.id] = messageViewModel;
+      body.append(messageViewModel.viewElement);
+    });
+    messageCodingTable.append(body);
+    attachEventListeners(messageCodingTable);
+
     CodeSelector.activeCodeSelector = messages[0].codeSelectors[0];
   }
 


### PR DESCRIPTION
Addresses: #41 

When we moved to a global event handler, we didn't add logic to remove the handler, so each time we recreate the table we add a new set.

I'm not super happy about this as a solution - but it seems less confusing that storing the stream subscriptions.

It would be nicer if there was a way of making the whole of the coding table self-contained, so that the listeners were attached to the thing that we were clearing up when we discarded the contents.