### PR TITLE
Insert label at the beginning of label list when added manually

### DIFF
--- a/webapp/lib/view_model.dart
+++ b/webapp/lib/view_model.dart
@@ -50,7 +50,7 @@ class MessageViewModel {
     if (VERBOSE) print("Message code-value: $messageId $schemeId => $valueId");
 
     // Update the data-model by prepending this decision
-    message.labels.add(
+    message.labels.insert(0,
       new Label(schemeId, new DateTime.now(), valueId,
         new Origin(auth.getUserEmail(), auth.getUserName())
         ));


### PR DESCRIPTION
This is more of a question rather than a change, but I think when we switched in eaad8ce16f from getting the last label to getting the first, we should have added to the beginning of the label list rather than the end?