### PR TITLE
Adjust checkbox and un-coding behaviour

### DIFF
--- a/webapp/lib/data_model.dart
+++ b/webapp/lib/data_model.dart
@@ -66,6 +66,8 @@ class Label {
   double confidence;
   bool checked;
 
+  static const MANUALLY_UNCODED = 'SPECIAL-MANUALLY_UNCODED';
+
   Label(this.schemeId, this.dateTime, this.codeId, this.labelOrigin, {this.confidence = 1.0, this.checked = true});
   Label.fromFirebaseMap(Map label) {
     schemeId = label['SchemeID'];

--- a/webapp/web/buttons.css
+++ b/webapp/web/buttons.css
@@ -108,8 +108,8 @@ input[type="checkbox"]:after {
   top: 3px;
   width: 4px;
   height: 8px;
-  border: solid #c9c9c9;
-  border-width: 0 3px 3px 0;
+  border: solid #555555;
+  border-width: 0 2px 2px 0;
   -webkit-transform: rotate(45deg);
   -ms-transform: rotate(45deg);
   transform: rotate(45deg);


### PR DESCRIPTION
Demo: https://www.cl.cam.ac.uk/~mcm79/codav2_demos/checkbox-2018-10-15/?dataset=test_dataset_id

What should happen:
- unchecking an unlabelled code should not work
- checking and unchecking a labelled code should work
- unlabelling a code should appear in the console logs and Firebase as SPECIAL-MANUALLY_UNLABELLED

Thanks and please let me know if I've missed anything!