### PR TITLE
Select first code selector on initial load of messages

### DIFF
--- a/webapp/lib/main_ui.dart
+++ b/webapp/lib/main_ui.dart
@@ -133,6 +133,11 @@ class CodaUI {
       dataset.messages.add(message);
       body.append(messageViewModel.viewElement);
     });
+
+    // It's the first time we're adding messages to the table, select the first code selector
+    if (CodeSelector.activeCodeSelector == null) {
+      CodeSelector.activeCodeSelector = messages.first.codeSelectors.first;
+    }
   }
 
   void updateMessagesInView(List<Message> changedMessages) {


### PR DESCRIPTION
Fixes #64 

I introduced this bug when I switched to the real-time way of loading messages.