### PR TITLE
Add active message indicator

### DIFF
--- a/data_tools/validate_code_scheme.py
+++ b/data_tools/validate_code_scheme.py
@@ -10,7 +10,7 @@ import argparse
 def verify_JSON_path(scheme_path):
     f = open(scheme_path, 'r')
     scheme = json.loads(f.read())
-    verify_scheme(scheme)
+    return verify_scheme(scheme)
 
 def verify_scheme(scheme):
     assert "SchemeID" in scheme.keys()

--- a/webapp/lib/view_model.dart
+++ b/webapp/lib/view_model.dart
@@ -134,11 +134,19 @@ class CodeSelector {
   static CodeSelector get activeCodeSelector => _activeCodeSelector;
   static set activeCodeSelector(CodeSelector activeCodeSelector) {
     _activeCodeSelector?.viewElement?.classes?.toggle('active', false);
-    _activeCodeSelector?.viewElement?.parent?.parent?.classes?.toggle('active', false);
+
+    if (_activeCodeSelector?.viewElement != null) {
+      Element messageElement = getAncestors(_activeCodeSelector.viewElement).firstWhere((a) => a.classes.contains('message-row'));
+      messageElement.classes.toggle('active', false);
+    }
+    // _activeCodeSelector?.viewElement?.parent?.parent?.classes?
     // Focus on the new code selector
     _activeCodeSelector = activeCodeSelector;
     _activeCodeSelector.viewElement.classes.toggle('active', true);
-    _activeCodeSelector?.viewElement?.parent?.parent?.classes?.toggle('active', true);
+    if (_activeCodeSelector?.viewElement != null) {
+      Element messageElement = getAncestors(_activeCodeSelector.viewElement).firstWhere((a) => a.classes.contains('message-row'));
+      messageElement.classes.toggle('active', true);
+    }
     _activeCodeSelector.dropdown.focus();
   }
 

--- a/webapp/lib/view_model.dart
+++ b/webapp/lib/view_model.dart
@@ -134,9 +134,11 @@ class CodeSelector {
   static CodeSelector get activeCodeSelector => _activeCodeSelector;
   static set activeCodeSelector(CodeSelector activeCodeSelector) {
     _activeCodeSelector?.viewElement?.classes?.toggle('active', false);
+    _activeCodeSelector?.viewElement?.parent?.parent?.classes?.toggle('active', false);
     // Focus on the new code selector
     _activeCodeSelector = activeCodeSelector;
     _activeCodeSelector.viewElement.classes.toggle('active', true);
+    _activeCodeSelector?.viewElement?.parent?.parent?.classes?.toggle('active', true);
     _activeCodeSelector.dropdown.focus();
   }
 

--- a/webapp/web/main.css
+++ b/webapp/web/main.css
@@ -162,6 +162,8 @@ main tbody {
   text-align: left;
 }
 
+
+
 #message-coding-table thead td {
   /* Sticky header */
   position: sticky;
@@ -182,6 +184,10 @@ main tbody {
 
 .message-id {
   width: 50px;
+}
+
+.message-row.active {
+  border-left: 5px solid #000000;
 }
 
 .scheme-title .scheme-id {


### PR DESCRIPTION
Per @ParthaMoman request (https://github.com/AfricasVoices/CodaV2/issues/112)

I'm not super happy about ln 137 and ln 141 - they add an explicit coupling in the number of elements in the DOM tree between the Code selector and the message tree. Is there a simple way to say 'search upward for first ```message-row```'?