### PR TITLE
Make the table break too long single-word messages on multiple lines

### DIFF
--- a/webapp/lib/main_ui.dart
+++ b/webapp/lib/main_ui.dart
@@ -166,7 +166,9 @@ class CodaUI {
     TableRowElement headerRow = header.addRow();
     headerRow.addCell()
       ..classes.add('message-seq')
-      ..text = 'Seq'
+      ..append(new SpanElement()
+        ..classes.add('seq-name')
+        ..text = 'Seq')
       ..append(new SpanElement()
         ..classes.addAll(['button', 'sort', 'asc']));
     headerRow.addCell()

--- a/webapp/web/main.css
+++ b/webapp/web/main.css
@@ -171,6 +171,7 @@ main tbody {
 
 #message-coding-table {
   outline: none;
+  table-layout: fixed;
 }
 
 #message-coding-table td {
@@ -202,6 +203,9 @@ main tbody {
   width: 50px;
 }
 
+.message-text {
+  word-wrap: break-word;
+}
 
 .button.sort {
   display: inline-block;
@@ -211,7 +215,7 @@ main tbody {
 }
 
 td.message-seq .button.sort { /* First sorting button is a bit different */
-  margin: 0 0 0 8px;
+  margin: 0 0 0 6px;
   vertical-align: initial;
 }
 


### PR DESCRIPTION
PTAL @lukechurch 
The key lines are `table-layout: fixed` and `word-wrap: break-word`. The slight changes to the layout for the `seq` column are needed b/c changing the table layout to fixed made the sorting button go to the next line.

Thanks!