### PR TITLE
Write the metrics back to the dataset if they weren’t there

### DIFF
--- a/data_tools/compute_coding_progress.py
+++ b/data_tools/compute_coding_progress.py
@@ -27,7 +27,7 @@ for id in ids:
     if metrics != None:
         data['coding_progress'][id] = metrics   
         continue
-        
+
     for message in fcw.get_all_messages(id):
         messages.append(message)
         if len(message["Labels"]) > 0:
@@ -35,6 +35,7 @@ for id in ids:
 
     data['coding_progress'][id]['messages_count'] = len(messages)
     data['coding_progress'][id]['messages_with_label'] = messages_with_labels
+    fcw.set_dataset_metrics(id, data['coding_progress'][id])
 
 data["last_update"] = strftime("%Y-%m-%d %H:%M:%S", gmtime())
 

--- a/data_tools/firebase_client_wrapper.py
+++ b/data_tools/firebase_client_wrapper.py
@@ -63,6 +63,9 @@ def push_coding_status(coding_status):
 def get_dataset_metrics(dataset_id):
     return client.document(u'datasets/{}/metrics/messages'.format(dataset_id)).get().to_dict()
 
+def set_dataset_metrics(dataset_id, metrics_map):
+    message_metrics_ref = client.document(u'datasets/{}/metrics/messages'.format(dataset_id))
+    message_metrics_ref.set(metrics_map)
 
 def set_users(dataset_id, users_list):
     dataset_ref = get_dataset_ref(dataset_id)


### PR DESCRIPTION
FYI @IsaackMwenda 

This addresses part of the excessive read problem as we aren't repeatedly reading the whole dataset if the metrics weren't present. It's a temporary solution until we have a more complete design in place