### PR TITLE
Pin Functions version

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -21,5 +21,8 @@
     "eslint": "^4.12.0",
     "eslint-plugin-promise": "^3.6.0"
   },
+  "engines": {
+    "node": "6"
+  },
   "private": true
 }


### PR DESCRIPTION
@marianamarasoiu There's a change to the way that Firebase functions are deployed - by the end of March they're going to need pinned versions