### PR TITLE
Fix NRE if autocoding metrics not present

### DIFF
--- a/webapp/lib/firebase_tools.dart
+++ b/webapp/lib/firebase_tools.dart
@@ -191,7 +191,6 @@ void setupListenerForAutocodingUpdates(Dataset dataset, AutocodingProgressUpdate
     }
 
     var snapshotData = querySnapshot.data();
-
     log.trace("setupListenerForAutocodingUpdates", "Starting processing ${snapshotData}.");
 
     double fractionComplete = 0.0;

--- a/webapp/lib/firebase_tools.dart
+++ b/webapp/lib/firebase_tools.dart
@@ -190,8 +190,15 @@ void setupListenerForAutocodingUpdates(Dataset dataset, AutocodingProgressUpdate
       return;
     }
 
-    log.trace("setupListenerForAutocodingUpdates", "Starting processing ${querySnapshot.data()}.");
-    var fractionComplete = querySnapshot.data()["fractionComplete"];
+    var snapshotData = querySnapshot.data();
+
+    log.trace("setupListenerForAutocodingUpdates", "Starting processing ${snapshotData}.");
+
+    double fractionComplete = 0.0;
+    if (snapshotData != null) {
+      fractionComplete = querySnapshot.data()["fractionComplete"];
+    }
+    
     listener(fractionComplete);
   });
 }


### PR DESCRIPTION
@marianamarasoiu I thought I would help - and it turns out I created the bug in the first place.

If autoCode hasn't been clicked, the metrics won't be written into the dataset, so the query object will return null.

Addresses #205 and #204.

