### PR TITLE
Sort downloaded messages by sequence number

### DIFF
--- a/data_tools/get.py
+++ b/data_tools/get.py
@@ -44,5 +44,6 @@ if CONTENT_TYPE in ["all", "messages"]:
     messages = []
     for message in fcw.get_all_messages(DATASET_ID):
         messages.append(message)
+    messages.sort(key=lambda msg: msg["SequenceNumber"])
     print (json.dumps(messages, indent=2))
 


### PR DESCRIPTION
Exporting downloaded messages sorted by the MessageID is confusing, and doesn't match what we upload or what users see in Coda. This makes things more consistent, and allows us to "shard" correctly by pulling an existing dataset then pushing it back again.