### PR TITLE
Fix dev server instructions not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ Before the first run and if any new packages are added, the Dart package manager
 CodaV2/webapp$ pub get
 ```
 
-You can now run the `CodaV2/webapp/` project with `webdev serve`:
+You can now run the `CodaV2/webapp/` project with `run_dev_local.sh`. This copies the developer firebase constants into 
+the `web/assets` directory, then starts a development server via `webdev serve`:
 
 ```
-CodaV2/webapp$ webdev serve
+CodaV2/webapp$ ./run_dev_local.sh
 ```
 
 When you're ready for deployment, the code needs to be converted from Dart to JavaScript:

--- a/webapp/run_dev_local.sh
+++ b/webapp/run_dev_local.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 
 # cd to script directory if not already there
 SCRIPT_PATH=${0%/*}


### PR DESCRIPTION
Following the instructions in the README, I can't actually run Coda correctly locally. This fixes the problem by:
 - Making `run_dev_local.sh` executable
 - Updating the README to refer to `run_dev_local.sh` instead of `webdev serve` 