### PR TITLE
Make deploy.sh executable and fix errors in deployment documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,15 @@ You can run the tests with the following command:
 CodaV2/webapp$ pub run test -p chrome
 ```
 
-To deploy the web app to Firebase run the `deploy.sh` script contained in the `deployment/` folder. This will build the webapp and then deploy it to Firebase for serving. The deploy script requires access to a firebase constants config file which should be passed as a command line argument as follows:
+To deploy the web app to Firebase, first install the Firebase functions dependencies:
 
 ```
-CodaV2/deployment$ ./deploy.sh path/to/firebase/deployment/constants.json
+CodaV2/functions$ npm install
+```
+
+Then run the `deploy.sh` script contained in the `deployment/` folder. This will build the webapp and then deploy it to Firebase for serving. 
+The deploy script requires access to a firebase constants config file which should be passed as a command line argument as follows:
+
+```
+CodaV2$ deployment/deploy.sh path/to/firebase/deployment/constants.json
 ```

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Exit immediately if a command exits with a non-zero status
 set -e
 


### PR DESCRIPTION
This is what I needed to do to be able to run the deploy scripts. Please correct me if I've misunderstood something.