### PR TITLE
Add "Next uncoded message" button

### DIFF
--- a/webapp/lib/main_ui.dart
+++ b/webapp/lib/main_ui.dart
@@ -475,7 +475,7 @@ class CodaUI {
     } // else, it's the last message, stop
   }
 
-  isMessageCoded(String messageID) {
+  bool isMessageCoded(String messageID) {
     Message message = messageList.messageMap[messageID].message;
 
     // Get the latest label from each scheme
@@ -493,7 +493,7 @@ class CodaUI {
     return false;
   }
   
-  selectNextUncodedMessage(String messageID, String schemeID) {
+  void selectNextUncodedMessage(String messageID, String schemeID) {
     MessageViewModel message = messageList.messageMap[messageID];
     int codeSelectorIndex = message.codeSelectors.indexWhere((codeSelector) => codeSelector.scheme.id == schemeID);
     int messageIndex = messageList.messages.indexOf(message);

--- a/webapp/lib/main_ui.dart
+++ b/webapp/lib/main_ui.dart
@@ -475,7 +475,7 @@ class CodaUI {
     } // else, it's the last message, stop
   }
 
-  messageCoded(String messageID) {
+  isMessageCoded(String messageID) {
     Message message = messageList.messageMap[messageID].message;
 
     // Get the latest label from each scheme
@@ -500,7 +500,7 @@ class CodaUI {
 
     // Search for an uncoded row below the current one.
     for (int i = messageIndex + 1; i < messageList.messages.length; i++) {
-      if (!messageCoded(messageList.messages[i].message.id)) {
+      if (!isMessageCoded(messageList.messages[i].message.id)) {
         CodeSelector.activeCodeSelector = messageList.messages[i].codeSelectors[codeSelectorIndex];
         return;
       }
@@ -508,7 +508,7 @@ class CodaUI {
 
     // Couldn't find an uncoded row below the current one, continue the search from the top of this dataset.
     for (int i = 0; i <= messageIndex; i++) {
-      if (!messageCoded(messageList.messages[i].message.id)) {
+      if (!isMessageCoded(messageList.messages[i].message.id)) {
         CodeSelector.activeCodeSelector = messageList.messages[i].codeSelectors[codeSelectorIndex];
         return;
       }

--- a/webapp/lib/main_ui.dart
+++ b/webapp/lib/main_ui.dart
@@ -39,6 +39,8 @@ class CodaUI {
   static InputElement jumpToNextUncodedCheckbox = querySelector('#jump-to-next-uncoded');
   static bool get jumpToNextUncoded => jumpToNextUncodedCheckbox.checked;
 
+  static ButtonElement nextUncodedMessageButton = querySelector('#next-uncoded-message');
+
   static ButtonElement autoCodeButton = querySelector('#autocode');
 
   Dataset dataset;
@@ -76,6 +78,14 @@ class CodaUI {
       if (continuousSorting) {
         sortTableView();
       }
+    });
+
+    nextUncodedMessageButton.onClick.listen((event) {
+      CodeSelector activeCodeSelector = CodeSelector.activeCodeSelector;
+      TableRowElement row = getAncestors(CodeSelector.activeCodeSelector.viewElement).firstWhere((e) => e.classes.contains('message-row'));
+      String messageId = row.attributes['message-id'];
+      
+      selectNextUncodedMessage(messageId, activeCodeSelector.scheme.id);
     });
 
     autoCodeButton.onClick.listen((event) {
@@ -463,6 +473,49 @@ class CodaUI {
         selectNextCodeSelectorVertical(messageList.messages[messageIndex + 1].message.id, CodeSelector.activeCodeSelector.scheme.id);
       }
     } // else, it's the last message, stop
+  }
+
+  messageCoded(String messageID) {
+    Message message = messageList.messageMap[messageID].message;
+
+    // Get the latest label from each scheme
+    var latest_labels = Map<String, Label>();
+    for (Label l in message.labels) {
+      latest_labels.putIfAbsent(l.schemeId, () => l);
+    }
+
+    // This message is coded if it contains a label that is checked.
+    for (Label l in latest_labels.values) {
+      if (l.checked) {
+        return true;
+      }
+    }
+    return false;
+  }
+  
+  selectNextUncodedMessage(String messageID, String schemeID) {
+    MessageViewModel message = messageList.messageMap[messageID];
+    int codeSelectorIndex = message.codeSelectors.indexWhere((codeSelector) => codeSelector.scheme.id == schemeID);
+    int messageIndex = messageList.messages.indexOf(message);
+
+    // Search for an uncoded row below the current one.
+    for (int i = messageIndex + 1; i < messageList.messages.length; i++) {
+      if (!messageCoded(messageList.messages[i].message.id)) {
+        CodeSelector.activeCodeSelector = messageList.messages[i].codeSelectors[codeSelectorIndex];
+        return;
+      }
+    }
+
+    // Couldn't find an uncoded row below the current one, continue the search from the top of this dataset.
+    for (int i = 0; i <= messageIndex; i++) {
+      if (!messageCoded(messageList.messages[i].message.id)) {
+        CodeSelector.activeCodeSelector = messageList.messages[i].codeSelectors[codeSelectorIndex];
+        return;
+      }
+    }
+
+    // Couldn't find any uncoded rows.
+    window.alert("Dataset is fully labelled");
   }
 
   void clearMessageCodingTable() {

--- a/webapp/web/index.html
+++ b/webapp/web/index.html
@@ -48,17 +48,25 @@
 
           <li>
             <div>
-              <label for="jump-to-next-uncoded">Jump to next uncoded</label>
+              <label for="jump-to-next-uncoded">Jump to next uncoded cell</label>
               <input id="jump-to-next-uncoded" type="checkbox" name="jump-to-next-uncoded">
             </div>
           </li>
 
           <li>
             <div>
+              <button id="next-uncoded-message" type="button" data-toggle="tooltip" data-placement="bottom" title="Next uncoded message">
+                Next uncoded message
+              </button>
+            </div>
+          </li>
+
+          <li>
+            <label>
               <button id="autocode" type="button" data-toggle="tooltip" data-placement="bottom" title="Auto code" hidden="false">
                 Auto Code
               </button>
-              <label id="autocode_progress" for="autocode" hidden="true"> ( 0% ) </div>
+              <label id="autocode_progress" for="autocode" hidden="true"> ( 0% ) </label>
             </div>
           </li>
 


### PR DESCRIPTION
<img width="705" alt="image" src="https://user-images.githubusercontent.com/7963608/78786483-b95f9a00-79a0-11ea-837b-ff6530213d0f.png">

Uses the terminology "message" for consistency with the rest of Coda's user interface and code base.