### PR TITLE
Set Message.LastUpdated to the Firestore server time when writing to Firestore

### DIFF
--- a/data_tools/firebase_client_wrapper.py
+++ b/data_tools/firebase_client_wrapper.py
@@ -165,7 +165,11 @@ def get_message_ids(dataset_id):
 def get_segment_messages(segment_id):
     messages = []
     for message in client.collection(u'datasets/{}/messages'.format(segment_id)).get():
-        messages.append(message.to_dict())
+        msg = message.to_dict()
+        if "LastUpdated" in msg:
+            msg["LastUpdated"] = msg["LastUpdated"].isoformat(timespec="microseconds")
+        messages.append(msg)
+
     return messages
 
 

--- a/data_tools/restore.py
+++ b/data_tools/restore.py
@@ -40,7 +40,7 @@ with open(BACKUP_PATH, 'r') as f:
             fcw.set_user_ids(segment_id, segment["users"])
             for scheme in segment["schemes"]:
                 fcw.set_code_scheme(segment_id, scheme)
-            fcw.add_and_update_segment_messages_content_batch(segment_id, segment["messages"])
+            fcw.restore_segment_messages_content_batch(segment_id, segment["messages"])
             fcw.set_segment_metrics(segment_id, segment["metrics"])
             print(f"Restore complete: segment {segment_id}")
 

--- a/webapp/lib/data_model.dart
+++ b/webapp/lib/data_model.dart
@@ -33,11 +33,14 @@ class Message {
   DateTime creationDateTime;
   List<Label> labels;
   Map<String, dynamic> otherData;
+  DateTime lastUpdated;
 
   Message(this.id, this.sequenceNumber, this.text, this.creationDateTime) {
     labels = [];
     otherData = {};
+    lastUpdated = null;
   }
+
   Message.fromFirebaseMap(Map message) {
     otherData = {};
     
@@ -62,6 +65,9 @@ class Message {
             labels.add(new Label.fromFirebaseMap(labelMap));
           }
           break;
+        case 'LastUpdated':
+          lastUpdated = value;
+          break;
         default:
           otherData[property] = value;
       }
@@ -75,7 +81,7 @@ class Message {
       "CreationDateTimeUTC" : creationDateTime.toIso8601String(),
       "Labels" : labels.map((f) => f.toFirebaseMap()).toList()
     };
-    // Write back the sequence nuber only if it's been explicitly set, either in the UI or from Firebase
+    // Write back the sequence number only if it's been explicitly set, either in the UI or from Firebase
     if (sequenceNumber != null) {
       result["SequenceNumber"] = sequenceNumber;
     }

--- a/webapp/lib/firebase_tools.dart
+++ b/webapp/lib/firebase_tools.dart
@@ -44,13 +44,15 @@ updateMessage(Dataset dataset, Message msg) {
   log.trace("updateMessage", "$msg");
 
   var docPath = "datasets/${dataset.id}/messages/${msg.id}";
+  var doc = msg.toFirebaseMap();
+  doc["LastUpdated"] = firestore.FieldValue.serverTimestamp();
 
   if (TEST_MODE) {
-    log.logFirestoreCall('updateMessage', '$docPath', msg.toFirebaseMap());
+    log.logFirestoreCall('updateMessage', '$docPath', doc);
     return;
   }
 
-  _firestoreInstance.doc(docPath).set(msg.toFirebaseMap()).then((_) {
+  _firestoreInstance.doc(docPath).set(doc).then((_) {
     log.trace("updateMessage", "Complete: ${msg.id}");
     log.perf("updateMessage", sw.elapsedMilliseconds);
     updateDatasetStatus(dataset);

--- a/webapp/test/view_model_test.dart
+++ b/webapp/test/view_model_test.dart
@@ -6,6 +6,8 @@ import 'dart:html';
 
 import 'package:test/test.dart';
 
+import 'package:firebase/firestore.dart' as firestore;
+
 import 'package:CodaV2/data_model.dart';
 import 'package:CodaV2/main_ui.dart';
 import 'package:CodaV2/config.dart' as config;
@@ -173,8 +175,11 @@ void main() {
       select.dispatchEvent(new Event('change'));
       await new Future.delayed(const Duration(milliseconds: 200));
 
+      var expectedContent = message.message.toFirebaseMap();
+      expectedContent["LastUpdated"] = firestore.FieldValue.serverTimestamp();
+
       expect(log.firestoreCallLog.last['callType'], 'updateMessage');
-      expect(log.firestoreCallLog.last['content'], message.message.toFirebaseMap());
+      expect(log.firestoreCallLog.last['content'], expectedContent);
       expect(message.codeSelectors[0].selectedOption, "code 2");
     });
 
@@ -194,8 +199,11 @@ void main() {
       select.dispatchEvent(new Event('change'));
       await new Future.delayed(const Duration(milliseconds: 200));
 
+      var expectedContent = message.message.toFirebaseMap();
+      expectedContent["LastUpdated"] = firestore.FieldValue.serverTimestamp();
+
       expect(log.firestoreCallLog.last['callType'], 'updateMessage');
-      expect(log.firestoreCallLog.last['content'], message.message.toFirebaseMap());
+      expect(log.firestoreCallLog.last['content'], expectedContent);
       expect(message.codeSelectors[1].selectedOption, "code 2");
       expect(message.codeSelectors[1].warning.classes.contains('hidden'), true);
     });


### PR DESCRIPTION
Updates the webapp and data tools to write a 'LastUpdated' field to Coda when updating a message object in Firestore.

Here's an example from the Firebase console when testing against Coda dev (message text omitted):
<img width="413" alt="image" src="https://user-images.githubusercontent.com/7963608/87548763-e0ff8600-c6a4-11ea-98d0-8de4a24beff3.png">

The changes are backwards-compatible with the current master version of the webapp, but unfortunately not data_tools because they are unable to json-serialize the DateTimeWithNanoseconds objects that Firestore timestamps get deserialized to, so we'd need to upgrade the data_tools versions in the pipelines before updating the webapp.
