### PR TITLE
Support incremental get

### DIFF
--- a/data_tools/firebase_client_wrapper.py
+++ b/data_tools/firebase_client_wrapper.py
@@ -165,12 +165,19 @@ def get_message_ids(dataset_id):
 # This is a much faster way of reading an entire dataset rather than repeated get_message calls
 def get_segment_messages(segment_id, last_updated_after=None, last_updated_before=None):
     """
+    Downloads messages from the requested segment, optionally filtering by when the messages were last updated.
+
+    If filtering by when the messages where last updated, only message objects which contain a LastUpdated field
+    will be returned.
 
     :param segment_id: Id of segment to download messages from
     :type segment_id: str
-    :param last_updated_after: If specified, filters the downloaded messages to only include
+    :param last_updated_after: If specified, filters the downloaded messages to only include messages with a LastUpdated
+                               field and where the LastUpdated field is later than last_updated_after.
     :type last_updated_after: datetime | None
-    :param last_updated_before:
+    :param last_updated_before: If specified, filters the downloaded messages to only include messages with a LastUpdated
+                                field and where the LastUpdated field is earlier than, or the same time as,
+                                last_updated_before.
     :type last_updated_before: datetime | None
     :return: Messages in this segment, filtered by 'LastUpdated' timestamp if requested
     :rtype: list of dict

--- a/data_tools/firebase_client_wrapper.py
+++ b/data_tools/firebase_client_wrapper.py
@@ -170,7 +170,7 @@ def get_segment_messages(segment_id, last_updated_after=None, last_updated_befor
     If filtering by when the messages where last updated, only message objects which contain a LastUpdated field
     will be returned.
 
-    :param segment_id: Id of segment to download messages from
+    :param segment_id: Id of segment to download messages from.
     :type segment_id: str
     :param last_updated_after: If specified, filters the downloaded messages to only include messages with a LastUpdated
                                field and where the LastUpdated field is later than last_updated_after.
@@ -179,7 +179,7 @@ def get_segment_messages(segment_id, last_updated_after=None, last_updated_befor
                                 field and where the LastUpdated field is earlier than, or the same time as,
                                 last_updated_before.
     :type last_updated_before: datetime | None
-    :return: Messages in this segment, filtered by 'LastUpdated' timestamp if requested
+    :return: Messages in this segment, filtered by 'LastUpdated' timestamp if requested.
     :rtype: list of dict
     """
     query = client.collection(f"datasets/{segment_id}/messages")
@@ -200,6 +200,20 @@ def get_segment_messages(segment_id, last_updated_after=None, last_updated_befor
 
 
 def get_all_messages(dataset_id, last_updated_after=None):
+    """
+    Downloads messages from the requested dataset, optionally filtering by when the messages were last updated.
+
+    If filtering by when the messages where last updated, only message objects which contain a LastUpdated field
+    will be returned.
+
+    :param dataset_id: Id of dataset to download messages from.
+    :type dataset_id: str
+    :param last_updated_after: If specified, filters the downloaded messages to only include messages with a LastUpdated
+                               field and where the LastUpdated field is later than last_updated_after.
+    :type last_updated_after: datetime | None
+    :return: Messages in this dataset, filtered by 'LastUpdated' timestamp if requested.
+    :rtype: list of dict
+    """
     segment_count = get_segment_count(dataset_id)
     if segment_count is None or segment_count == 1:
         return get_segment_messages(dataset_id, last_updated_after)

--- a/data_tools/firebase_client_wrapper.py
+++ b/data_tools/firebase_client_wrapper.py
@@ -1,5 +1,6 @@
 import json
 import time
+from datetime import datetime
 
 import firebase_admin
 from firebase_admin import credentials
@@ -162,14 +163,24 @@ def get_message_ids(dataset_id):
 
 
 # This is a much faster way of reading an entire dataset rather than repeated get_message calls
-def get_segment_messages(segment_id, last_updated_after=None):
-    if last_updated_after is None:
-        raw_messages = client.collection(f"datasets/{segment_id}/messages").get()
-    else:
-        raw_messages = client.collection(f"datasets/{segment_id}/messages") \
-            .where("LastUpdated", ">", last_updated_after) \
-            .order_by("LastUpdated") \
-            .get()
+def get_segment_messages(segment_id, last_updated_after=None, last_updated_before=None):
+    """
+
+    :param segment_id: Id of segment to download messages from
+    :type segment_id: str
+    :param last_updated_after: If specified, filters the downloaded messages to only include
+    :type last_updated_after: datetime | None
+    :param last_updated_before:
+    :type last_updated_before: datetime | None
+    :return: Messages in this segment, filtered by 'LastUpdated' timestamp if requested
+    :rtype: list of dict
+    """
+    query = client.collection(f"datasets/{segment_id}/messages")
+    if last_updated_after is not None:
+        query = query.where("LastUpdated", ">", last_updated_after)
+    if last_updated_before is not None:
+        query = query.where("LastUpdated", "<=", last_updated_before)
+    raw_messages = query.get()
 
     messages = []
     for message in raw_messages:
@@ -186,10 +197,40 @@ def get_all_messages(dataset_id, last_updated_after=None):
     if segment_count is None or segment_count == 1:
         return get_segment_messages(dataset_id, last_updated_after)
     else:
-        messages = []
+        # Get the messages for each segment
+        messages_by_segment = dict()  # of segment id -> list of message
         for segment_index in range(1, segment_count + 1):
-            messages.extend(get_segment_messages(id_for_segment(dataset_id, segment_index), last_updated_after))
+            segment_id = id_for_segment(dataset_id, segment_index)
+            messages_by_segment[segment_id] = get_segment_messages(segment_id, last_updated_after)
 
+        # Search the fetched segments for the most recently updated message across all the segments
+        dataset_last_updated = None
+        for segment_messages in messages_by_segment.values():
+            for msg in segment_messages:
+                if "LastUpdated" in msg:
+                    if dataset_last_updated is None or msg["LastUpdated"] > dataset_last_updated:
+                        dataset_last_updated = msg["LastUpdated"]
+
+        # Check all the segments for any messages between the latest one we fetched above and the most recently updated
+        # message seen in any segment. This is to ensure we don't miss any messages that were being labelled while
+        # we were pulling the separate segments, and is needed to maintain the consistency guarantees we need for
+        # incremental fetch.
+        for segment_id, segment_messages in messages_by_segment.items():
+            segment_last_updated = None
+            for msg in segment_messages:
+                if "LastUpdated" in msg:
+                    if segment_last_updated is None or msg["LastUpdated"] > segment_last_updated:
+                        segment_last_updated = msg["LastUpdated"]
+
+            if segment_last_updated is not None:
+                messages_by_segment[segment_id].extend(get_segment_messages(segment_id, segment_last_updated, dataset_last_updated))
+
+        # Combine all the messages downloaded from each segment.
+        messages = []
+        for segment_messages in messages_by_segment.values():
+            messages.extend(segment_messages)
+
+        # Check that there are no duplicate message ids.
         message_ids = set()
         for message in messages:
             assert message["MessageID"] not in message_ids, "Duplicate message found"

--- a/data_tools/get.py
+++ b/data_tools/get.py
@@ -1,45 +1,67 @@
+import argparse
+from datetime import datetime
+
+import pytz
+from dateutil.parser import isoparse
+
 import firebase_client_wrapper as fcw
 
 import json
-import sys
 
-if (len(sys.argv) < 2 or len(sys.argv) > 4):
-    print ("Usage python get.py crypto_token [datasetid] [all, users, messages, schemes]")
-    exit(1)
+parser = argparse.ArgumentParser(description="Gets data from Coda's Firestore")
 
-CONTENT_TYPE = "all"
+parser.add_argument("--previous-export-file-path",
+                    help="Path to a previous export of messages data. If provided, only messages changed since this "
+                         "export was created will be downloaded from Firestore, and the output data will be the "
+                         "contents of the previous export, updated with the latest data from Firestore")
+parser.add_argument("crypto_token_path", metavar="crypto-token-path",
+                    help="Path to the Firestore credentials file")
+parser.add_argument("dataset_id", metavar="dataset-id", help="Dataset to get data from")
+parser.add_argument("content_type", metavar="content-type", choices=["all", "users", "schemes", "messages"],
+                    help="Type of data to download")
 
-CRYPTO_TOKEN_PATH = sys.argv[1]
-fcw.init_client(CRYPTO_TOKEN_PATH)
+args = parser.parse_args()
 
-if (len(sys.argv) == 2):
-    print ("Datasets:")
-    ids = fcw.get_dataset_ids()
-    print (json.dumps(ids, indent=2))
-    exit(0)
+previous_export_file_path = args.previous_export_file_path
+crypto_token_path = args.crypto_token_path
+dataset_id = args.dataset_id
+content_type = args.content_type
 
-DATASET_ID = sys.argv[2]
+assert previous_export_file_path is None or content_type not in {"users", "schemes"}, \
+    "Cannot use previous-export-file-path with content-type 'users' or 'schemes'"
 
-if (len(sys.argv) == 4):
-    CONTENT_TYPE = sys.argv[3].lower()
+fcw.init_client(crypto_token_path)
 
-ALL = CONTENT_TYPE == "all"
+if content_type in ["all", "users"]:
+    if content_type == "all":
+        print("Users:")
+    print(json.dumps(fcw.get_user_ids(dataset_id), indent=2))
 
-if CONTENT_TYPE in ["all", "users"]:
-    if ALL: 
-        print ("Users:")
-    print (json.dumps(fcw.get_user_ids(DATASET_ID), indent=2))
+if content_type in ["all", "schemes"]:
+    if content_type == "all":
+        print("Schemes:")
+    schemes = fcw.get_all_code_schemes(dataset_id)
+    print(json.dumps(schemes, indent=2))
 
-if CONTENT_TYPE in ["all", "schemes"]:
-    if ALL:
-        print ("Schemes:")
-    schemes = fcw.get_all_code_schemes(DATASET_ID)
-    print (json.dumps(schemes, indent=2))
+if content_type in ["all", "messages"]:
+    if content_type == "all":
+        print("Messages:")
 
-if CONTENT_TYPE in ["all", "messages"]:
-    if ALL:
-        print ("Messages:")
-    messages = fcw.get_all_messages(DATASET_ID)
+    if previous_export_file_path is None:
+        previous_export = []
+        last_updated = None
+    else:
+        with open(previous_export_file_path) as f:
+            previous_export = json.load(f)
+        last_updated = datetime.min.replace(tzinfo=pytz.UTC)
+        for msg in previous_export:
+            if "LastUpdated" in msg and isoparse(msg["LastUpdated"]) > last_updated:
+                last_updated = isoparse(msg["LastUpdated"])
+
+    messages_dict = {msg["MessageID"]: msg for msg in previous_export}
+    new_messages_dict = {msg["MessageID"]: msg for msg in fcw.get_all_messages(dataset_id, last_updated_after=last_updated)}
+    messages_dict.update(new_messages_dict)
+
+    messages = list(messages_dict.values())
     messages.sort(key=lambda msg: msg["SequenceNumber"])
-    print (json.dumps(messages, indent=2))
-
+    print(json.dumps(messages, indent=2))


### PR DESCRIPTION
Adds support for optionally calling get.py with a previous export of a messages dataset from Coda. When provided with a previous export, get.py will only download messages which have changed in Coda since that export was made, which should reduce the cost of running high frequency pipelines. 

There were a few complexities arising from needing to handle segmented/non-segmented datasets, incremental + non-incremental fetch, and datasets which may or may not have a LastUpdated field set on some or all of the messages. The high level cases and and intended behaviours are:
- Pipelines which upgrade to this commit but don’t enable incremental mode will continue to work just as before, but the exports will now have better consistency guarantees surrounding parallel labelling of segments.
- Pipelines which enable incremental use fall into two categories:
    - The previous dataset (and therefore the dataset in Coda) contain LastUpdated fields: here get.py does an incremental get based on the LastUpdated fields, as expected.
    - The previous dataset does not contain a LastUpdated field anywhere, because LastUpdated hadn’t been enabled for this dataset when that export was made. In this case, get.py will do a full fetch of all of the data, but emit a warning that that’s what it’s doing. The only alternative I could think of in this case would be to do an incremental get with the start date as datetime.min, but I thought that was a more surprising behaviour and more likely to lead to bugs if we got the sequencing of upgrading the pipelines vs. the datasets in Coda wrong. If you see the warning, just set a LastUpdated field on at least one message in Coda to fix.

Finally, in order to support the optional flag, get.py has been rewritten to use argparse. I culled support for get.py with no arguments to get the list of dataset ids, use get_dataset_ids.py for this purpose instead.
