### PR TITLE
Automatically recompute coding progress in firebase_client_wrapper.add_and_update_messages_content_batch

### DIFF
--- a/data_tools/add.py
+++ b/data_tools/add.py
@@ -84,4 +84,3 @@ elif CONTENT_TYPE == "messages":
         added += 1
     
     fcw.add_and_update_dataset_messages_content_batch(DATASET_ID, messages_to_write)
-    cp.compute_coding_progress(DATASET_ID, force_recount=True)

--- a/data_tools/firebase_client_wrapper.py
+++ b/data_tools/firebase_client_wrapper.py
@@ -360,6 +360,7 @@ def add_and_update_dataset_messages_content_batch(dataset_id, messages, batch_si
         batch.commit()
         print(f"Final batch of {batch_counter} new messages committed")
 
+    segment_count = latest_segment_index
     if segment_count is None or segment_count == 1:
         compute_segment_coding_progress(dataset_id, existing_segment_messages[dataset_id], True)
     else:

--- a/data_tools/firebase_client_wrapper.py
+++ b/data_tools/firebase_client_wrapper.py
@@ -386,9 +386,7 @@ def compute_segment_coding_progress(segment_id, messages=None, force_recount=Fal
 
     schemes = {scheme["SchemeID"]: scheme for scheme in get_all_code_schemes(segment_id)}
 
-    for message in get_segment_messages(segment_id):
-        messages.append(message)
-
+    for message in messages:
         # Get the latest label from each scheme
         latest_labels = dict()  # of scheme id -> label
         for label in message["Labels"]:

--- a/data_tools/firebase_client_wrapper.py
+++ b/data_tools/firebase_client_wrapper.py
@@ -313,7 +313,9 @@ def add_and_update_dataset_messages_content_batch(dataset_id, messages, batch_si
         assert msg["SequenceNumber"] == message_id_to_sequence_number[msg["MessageID"]]
         msg["LastUpdated"] = firestore.firestore.SERVER_TIMESTAMP
 
-        batch.set(get_message_ref(message_id_to_segment_id[msg["MessageID"]], msg["MessageID"]), msg)
+        segment_id = message_id_to_segment_id[msg["MessageID"]]
+        batch.set(get_message_ref(segment_id, msg["MessageID"]), msg)
+        existing_segment_messages[segment_id][msg["MessageID"]] = msg
 
         batch_counter += 1
         if batch_counter >= batch_size / 2:  # Each document costs 2 writes due to the additional write needed by the server to set LastUpdated

--- a/data_tools/firebase_client_wrapper.py
+++ b/data_tools/firebase_client_wrapper.py
@@ -358,6 +358,89 @@ def add_and_update_dataset_messages_content_batch(dataset_id, messages, batch_si
         print(f"Final batch of {batch_counter} new messages committed")
 
 
+def compute_segment_coding_progress(segment_id, messages=None, force_recount=False):
+    """Compute and return the progress metrics for a given dataset.
+    This method will initialise the counts in Firestore if they do
+    not already exist."""
+    if not force_recount:
+        segment_metrics = get_segment_metrics(segment_id)
+        if segment_metrics is not None:
+            return segment_metrics
+
+    print(f"Performing a full recount of the metrics for segment {segment_id}...")
+    if messages is None:
+        messages = get_segment_messages(segment_id)
+    messages_with_labels = 0
+    wrong_scheme_messages = 0
+    not_coded_messages = 0
+
+    schemes = {scheme["SchemeID"]: scheme for scheme in get_all_code_schemes(segment_id)}
+
+    for message in get_segment_messages(segment_id):
+        messages.append(message)
+
+        # Get the latest label from each scheme
+        latest_labels = dict()  # of scheme id -> label
+        for label in message["Labels"]:
+            if label["SchemeID"] not in latest_labels:
+                latest_labels[label["SchemeID"]] = label
+
+        # Test if the message has a label (that isn't SPECIAL-MANUALLY_UNCODED), and
+        # if any of the latest labels are either WS or NC
+        message_has_label = False
+        message_has_ws = False
+        message_has_nc = False
+        for label in latest_labels.values():
+            if label["CodeID"] == "SPECIAL-MANUALLY_UNCODED":
+                continue
+
+            if not label["Checked"]:
+                continue
+
+            message_has_label = True
+            scheme_for_label = schemes[label["SchemeID"]]
+            code_for_label = None
+            for code in scheme_for_label["Codes"]:
+                if label["CodeID"] == code["CodeID"]:
+                    code_for_label = code
+            assert code_for_label is not None
+
+            if code_for_label["CodeType"] == "Control":
+                if code_for_label["ControlCode"] == "WS":
+                    message_has_ws = True
+                if code_for_label["ControlCode"] == "NC":
+                    message_has_nc = True
+
+        # Update counts appropriately
+        if message_has_label:
+            messages_with_labels += 1
+        if message_has_ws:
+            wrong_scheme_messages += 1
+        if message_has_nc:
+            not_coded_messages += 1
+
+    metrics = {
+        "messages_count": len(messages),
+        "messages_with_label": messages_with_labels,
+        "wrong_scheme_messages": wrong_scheme_messages,
+        "not_coded_messages": not_coded_messages
+    }
+
+    # Write the metrics back if they weren't stored
+    set_segment_metrics(segment_id, metrics)
+    return metrics
+
+
+def compute_coding_progress(dataset_id, force_recount=False):
+    segment_count = get_segment_count(dataset_id)
+    if segment_count is None or segment_count == 1:
+        compute_segment_coding_progress(dataset_id, force_recount=force_recount)
+    else:
+        for segment_index in range(1, segment_count + 1):
+            segment_id = id_for_segment(dataset_id, segment_index)
+            compute_segment_coding_progress(segment_id, force_recount=force_recount)
+
+
 def delete_segment(segment_id):
     # Delete code schemes
     segment_code_schemes_path = f"datasets/{segment_id}/code_schemes"

--- a/data_tools/firebase_client_wrapper.py
+++ b/data_tools/firebase_client_wrapper.py
@@ -357,6 +357,8 @@ def add_and_update_dataset_messages_content_batch(dataset_id, messages, batch_si
         batch.commit()
         print(f"Final batch of {batch_counter} new messages committed")
 
+    compute_coding_progress(dataset_id, force_recount=True)
+
 
 def compute_segment_coding_progress(segment_id, messages=None, force_recount=False):
     """Compute and return the progress metrics for a given dataset.

--- a/data_tools/set.py
+++ b/data_tools/set.py
@@ -52,8 +52,4 @@ elif CONTENT_TYPE == "messages":
     
     messages = json_data
     fcw.add_and_update_dataset_messages_content_batch(DATASET_ID, messages)
-    print("Updated messages")
-
-    print('Updating metrics for dataset: {}'.format(DATASET_ID))
-    cp.compute_coding_progress(DATASET_ID, force_recount=True)
     print('Done')


### PR DESCRIPTION
This has two main advantages:
 - Users of the main function for adding/setting messages no longer need to remember to update the metrics afterwards
 - We can update metrics without needing to read the entire dataset from Firestore again, which makes updating the datasets cheaper.

Note that I had to move compute_coding_progress from compute_coding_progress.py to firebase_client_wrapper.py.