### PR TITLE
Add firebase_client_wrapper.add_messages_content_batch

### DIFF
--- a/data_tools/add.py
+++ b/data_tools/add.py
@@ -1,7 +1,6 @@
 import json
 import sys
 
-import compute_coding_progress as cp
 import firebase_client_wrapper as fcw
 import validate_code_scheme
 import validate_message_structure
@@ -83,4 +82,4 @@ elif CONTENT_TYPE == "messages":
         messages_to_write.append(message)
         added += 1
     
-    fcw.add_and_update_dataset_messages_content_batch(DATASET_ID, messages_to_write)
+    fcw.add_messages_content_batch(DATASET_ID, messages_to_write)

--- a/data_tools/firebase_client_wrapper.py
+++ b/data_tools/firebase_client_wrapper.py
@@ -272,7 +272,7 @@ def add_messages_content_batch(dataset_id, messages, batch_size=500):
 
     Note: This method does not validate the messages to upload for presence in Firestore, so if a message already exists
     with the given id it will be overwritten or duplicated. If you need to filter messages for those which haven't
-    been added yet, use `add_or_update_messages_content_batch` instead.
+    been added yet, use `add_and_update_messages_content_batch` instead.
 
     :param dataset_id: Id of dataset to add messages to.
     :type dataset_id: str

--- a/data_tools/firebase_client_wrapper.py
+++ b/data_tools/firebase_client_wrapper.py
@@ -267,14 +267,37 @@ def restore_segment_messages_content_batch(dataset_id, messages, segment_index=N
 
 
 def add_messages_content_batch(dataset_id, messages, batch_size=500):
+    """
+    Adds messages to a dataset.
+
+    Note: This method does not validate the messages to upload for presence in Firestore, so if a message already exists
+    with the given id it will be overwritten or duplicated. If you need to filter messages for those which haven't
+    been added yet, use `add_or_update_messages_content_batch` instead.
+
+    :param dataset_id: Id of dataset to add messages to.
+    :type dataset_id: str
+    :param messages: Messages to add to the dataset.
+    :type messages: list of dict
+    :param batch_size: Number of writes to perform per batch when writing to Firestore. Each message costs 2 writes.
+    :type batch_size: int
+    """
     for msg in messages:
         assert "SequenceNumber" in msg
 
+    if len(messages) == 0:
+        # Save time and read costs by not reading anything from Firestore when there's nothing to upload.
+        print("add_messages_content_batch called with 0 messages; returning immediately without touching Firestore")
+        return
+
+    existing_segment_messages = dict()  # of segment id -> (dict of message id -> Message)
+    latest_segment_index = get_segment_count(dataset_id)
+    latest_segment_id = id_for_segment(dataset_id, latest_segment_index)
+    # Note: We need to read the latest segment so we know how big it is, but there's no need to check previous segments.
+    existing_segment_messages[latest_segment_id] = get_segment_messages(id_for_segment(latest_segment_id))
+    latest_segment_size = len(existing_segment_messages[latest_segment_id])
+
     batch = client.batch()
     batch_counter = 0
-    latest_segment_index = get_segment_count(dataset_id)
-    # TODO: Remove this call to Firestore for all documents in this segment, if possible
-    latest_segment_size = len(get_segment_messages(id_for_segment(dataset_id, latest_segment_index)))
     for i, msg in enumerate(messages):
         msg = msg.copy()
         msg["LastUpdated"] = firestore.firestore.SERVER_TIMESTAMP
@@ -283,8 +306,11 @@ def add_messages_content_batch(dataset_id, messages, batch_size=500):
             create_next_segment(dataset_id)
             latest_segment_index = get_segment_count(dataset_id)
             latest_segment_size = 0
+            existing_segment_messages[id_for_segment(dataset_id, latest_segment_index)] = []
 
-        batch.set(get_message_ref(id_for_segment(dataset_id, latest_segment_index), msg["MessageID"]), msg)
+        segment_id = id_for_segment(dataset_id, latest_segment_index)
+        batch.set(get_message_ref(segment_id, msg["MessageID"]), msg)
+        existing_segment_messages[segment_id].append(msg)
         latest_segment_size += 1
 
         batch_counter += 1
@@ -296,6 +322,9 @@ def add_messages_content_batch(dataset_id, messages, batch_size=500):
     if batch_counter > 0:
         batch.commit()
         print(f"Final batch of {batch_counter} new messages committed")
+
+    for segment_id, segment_messages in existing_segment_messages.items():
+        compute_segment_coding_progress(segment_id, segment_messages, True)
 
 
 def add_and_update_dataset_messages_content_batch(dataset_id, messages, batch_size=500):

--- a/data_tools/firebase_client_wrapper.py
+++ b/data_tools/firebase_client_wrapper.py
@@ -266,6 +266,38 @@ def restore_segment_messages_content_batch(dataset_id, messages, segment_index=N
     print("Written {} messages".format(i))
 
 
+def add_messages_content_batch(dataset_id, messages, batch_size=500):
+    for msg in messages:
+        assert "SequenceNumber" in msg
+
+    batch = client.batch()
+    batch_counter = 0
+    latest_segment_index = get_segment_count(dataset_id)
+    # TODO: Remove this call to Firestore for all documents in this segment, if possible
+    latest_segment_size = len(get_segment_messages(id_for_segment(dataset_id, latest_segment_index)))
+    for i, msg in enumerate(messages):
+        msg = msg.copy()
+        msg["LastUpdated"] = firestore.firestore.SERVER_TIMESTAMP
+
+        if latest_segment_size >= MAX_SEGMENT_SIZE:
+            create_next_segment(dataset_id)
+            latest_segment_index = get_segment_count(dataset_id)
+            latest_segment_size = 0
+
+        batch.set(get_message_ref(id_for_segment(dataset_id, latest_segment_index), msg["MessageID"]), msg)
+        latest_segment_size += 1
+
+        batch_counter += 1
+        if batch_counter >= batch_size / 2:  # Each document costs 2 writes due to the additional write needed by the server to set LastUpdated
+            batch.commit()
+            print(f"Batch of {batch_counter} new messages committed, progress: {i + 1} / {len(messages)}")
+            batch_counter = 0
+            batch = client.batch()
+    if batch_counter > 0:
+        batch.commit()
+        print(f"Final batch of {batch_counter} new messages committed")
+
+
 def add_and_update_dataset_messages_content_batch(dataset_id, messages, batch_size=500):
     # Get existing messages by segment, so we then find:
     #   - The location and sequence number of existing messages.
@@ -450,38 +482,6 @@ def compute_coding_progress(dataset_id, force_recount=False):
         for segment_index in range(1, segment_count + 1):
             segment_id = id_for_segment(dataset_id, segment_index)
             compute_segment_coding_progress(segment_id, force_recount=force_recount)
-
-
-def add_messages_content_batch(dataset_id, messages, batch_size=500):
-    for msg in messages:
-        assert "SequenceNumber" in msg
-
-    batch = client.batch()
-    batch_counter = 0
-    latest_segment_index = get_segment_count(dataset_id)
-    # TODO: Remove this call to Firestore for all documents in this segment, if possible
-    latest_segment_size = len(get_segment_messages(id_for_segment(dataset_id, latest_segment_index)))
-    for i, msg in enumerate(messages):
-        msg = msg.copy()
-        msg["LastUpdated"] = firestore.firestore.SERVER_TIMESTAMP
-
-        if latest_segment_size >= MAX_SEGMENT_SIZE:
-            create_next_segment(dataset_id)
-            latest_segment_index = get_segment_count(dataset_id)
-            latest_segment_size = 0
-
-        batch.set(get_message_ref(id_for_segment(dataset_id, latest_segment_index), msg["MessageID"]), msg)
-        latest_segment_size += 1
-
-        batch_counter += 1
-        if batch_counter >= batch_size / 2:  # Each document costs 2 writes due to the additional write needed by the server to set LastUpdated
-            batch.commit()
-            print(f"Batch of {batch_counter} new messages committed, progress: {i + 1} / {len(messages)}")
-            batch_counter = 0
-            batch = client.batch()
-    if batch_counter > 0:
-        batch.commit()
-        print(f"Final batch of {batch_counter} new messages committed")
 
 
 def delete_segment(segment_id):


### PR DESCRIPTION
Review #263 first.

This removes unnecessary message reads when adding messages. add.py downloads all the messages to decide which to add, then again in add_and_update_messages_content_batch because that function needs to check for which segment a message is in if it's updating. By providing a function that handles the add case only, we can reduce the second set of reads from the entire dataset to just the latest segment (to check its size), and then to 0 once Coda is updated to work on non-segmented datasets again. 