### PR TITLE
Add logging for how many messages to be added vs how many to be skipped

### DIFF
--- a/data_tools/add.py
+++ b/data_tools/add.py
@@ -83,5 +83,7 @@ elif CONTENT_TYPE == "messages":
         messages_to_write.append(message)
         added += 1
     
+    print ("To add: {}, Skipping: {}".format(added, skipped_existing))
+
     fcw.add_and_update_dataset_messages_content_batch(DATASET_ID, messages_to_write)
     cp.compute_coding_progress(DATASET_ID, force_recount=True)


### PR DESCRIPTION
It's similar to the print statement we already have for code schemes, it's just pre-upload rather than post-upload.

(I found it helpful to have this extra info when uploading new messages to Coda earlier today.)
